### PR TITLE
Expanded the landing page

### DIFF
--- a/_posts/2017-10-20-home.md
+++ b/_posts/2017-10-20-home.md
@@ -7,21 +7,48 @@ categories: posts
 
 # Welcome to the velocyto homepage!
 
-`velocyto` (velox + κύτος, quick cell) is a package for the analysis of expression dynamics single cell RNA seq data, in particuar it allows the estimation of the RNA velocity of single cells.
+`velocyto` (velox + κύτος, quick cell) is a package for the analysis of expression dynamics in single cell RNA seq data. In particular, it enables estimations of RNA velocities of single cells by distinguishing unspliced and spliced mRNAs in standard single-cell RNA sequencing protocols (see pre-print below for more information).
 
 ## Implementations
 
-`veloctyo` comes into different tastes so you can choose the implementation that fits you best:
+`veloctyo` currently has two different implementations:
 
-[**velocyto.py**](http://velocyto.org/velocyto.py/)
+### velocyto.py
 
-[**velocyto.R**](https://github.com/velocyto-team/velocyto.R)
+The Python implementation includes a [command line tool](http://velocyto.org/velocyto.py/tutorial/index.html#running-the-cli) and an [analysis pipeline](http://velocyto.org/velocyto.py/tutorial/analysis.html#analysis).
 
+See [the detailed documentation](http://velocyto.org/velocyto.py/) for [installation instructions](http://velocyto.org/velocyto.py/install/index.html), [tutorials](http://velocyto.org/velocyto.py/tutorial/index.html) and an overview of [the full API](http://velocyto.org/velocyto.py/fullapi/index.html).
+
+Example Jupyter notebooks are available at the [velocyto-notebooks Github repository](https://github.com/velocyto-team/velocyto-notebooks/tree/master/python).
+
+Report software or documentation issues at the [velocyto.py Github repository](https://github.com/velocyto-team/velocyto.py). If you would like to contribute to development, please contact the authors.
+
+### velocyto.R
+
+#### Installation
+
+The easiest way to install velocyto.R is using `devtools::install_github()` from R:
+
+```R
+library(devtools)
+install_github("velocyto-team/velocyto.R")
+```
+You need to have boost (e.g. `sudo apt-get install libboost-dev`) and openmp libraries installed.
+
+#### velocyto.R Tutorials
+
+- [Chromaffin / SMART-seq2](http://pklab.med.harvard.edu/velocyto/notebooks/R/chromaffin.nb.html) - this example shows how to annotate SMART-seq2 reads from bam file and estimate RNA velocity.
+
+- [Dentate Gyrus / loom](http://pklab.med.harvard.edu/velocyto/notebooks/R/DG1.nb.html) - this example shows how to load spliced/unspliced matrices from loom files prepared by [velocyto.py CLI](http://velocyto.org/velocyto.py/tutorial/index.html#running-the-cli), use [pagoda2](https://github.com/hms-dbmi/pagoda2) to cluster/embed cells, and then visualize RNA velocity on that embedding.
+
+- [Mouse BM / dropEst](http://pklab.med.harvard.edu/velocyto/notebooks/R/SCG71.nb.html) - this example shows how to start analysis using dropEst count matrices, which can calculated from inDrop or 10x bam files using [dropEst pipeline](https://github.com/hms-dbmi/dropEst/). It then uses [pagoda2](https://github.com/hms-dbmi/pagoda2) to cluster/embed cells, and then visualize RNA velocity on that embedding.
+
+Report software or documentation issues at the [velocyto.R Github repository](https://github.com/velocyto-team/velocyto.R). If you would like to contribute to development, please contact the authors.
 
 ---
-**NOTE**
+## **NOTE**
 
-`velocyto` is currently in alpha release. Some features are still under development. If you find problems with the software report the issue in the implementation Github page (python or R). If you would like to contribute please contact the authors.
+`velocyto` is currently in alpha release. Some features are still under development. If you find problems with the software or errors in the documentation, report the issue in the appropriate Github repository ([velocyto.py](https://github.com/velocyto-team/velocyto.py) or [velocyto.R](https://github.com/velocyto-team/velocyto.R)). If you would like to contribute please contact the authors.
 
 ---
 


### PR DESCRIPTION
I think the landing page is a bit too minimal. It would benefit from a slightly more elaborate introduction for the uninitiated, and from having direct links to specific information that users are likely looking for. 

The idea is to make things a bit easier to find for both newcomers, and for people looking for something specific, like the source code or example Jupyter notebooks.

Before, `velocyto.py` linked to the python documentation, `velocyto.R` linked to the source code (I assume R does not have the same style of documentating itself as Python does). Neither link signified where it would send you. Example of why this is annoying: I was looking for the python source code, searched for "velocyto", landed on this page, clicked through to the documentation (which I did not expect), then had to look through the documentation to find a link to the repository.

Links and explanations were added to both implementations. I also inlined the entire velocyto.R documentation, since most users just want to install it quickly, and having to navigate to the github page for documentation that is so short is pretty silly.

Also: yes, I know that I link to the github repo in both implementation sections and the note about this being alpha software. Easy-to-use documentation should contain relevant information in places where users *are most likely to look*, even if this creates some redundancy.